### PR TITLE
feat: Handle Directory Imports, Node Builtins

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -85,7 +85,7 @@ async function isBuiltin(path: string): Promise<boolean> {
 
 async function getIsEsm(build: PluginBuild, options: PluginOptions): Promise<boolean> {
   if (typeof options.esm === 'undefined') {
-    return build.initialOptions.define?.TSUP_FORMAT === '"esm"';
+    return build.initialOptions.define?.TSUP_FORMAT === '"esm"' || build.initialOptions.format === 'esm';
   }
 
   if (typeof options.esm === 'boolean') {

--- a/src/index.ts
+++ b/src/index.ts
@@ -76,7 +76,7 @@ function getFilter(options: PluginOptions): RegExp {
 let builtins: string[] | null = null;
 
 async function isBuiltin(path: string): Promise<boolean> {
-  if (builtins == null) {
+  if (builtins === null) {
     builtins = (await import('node:module')).builtinModules;
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import type { BuildOptions, OnLoadOptions, OnResolveArgs, OnResolveResult, Plugin, PluginBuild } from 'esbuild';
 import { stat } from 'node:fs/promises';
-import { extname, join, sep } from 'node:path';
+import { extname, join } from 'node:path';
 
 export interface PluginOptions {
   /**
@@ -174,8 +174,8 @@ async function handleResolve(args: OnResolveArgs, build: PluginBuild, options: P
         // If the import path refers to a directory it most likely actually refers to a
         // `index.*` file in said directory due to Node's module resolution
         if (await isDirectory(args.resolveDir, path)) {
-          // This uses `path.sep` instead of `path.join` here because `join` removes potential "./" prefixes
-          path = `${path}${sep}index`;
+          // This uses `/` instead of `path.join` here because `join` removes potential "./" prefixes
+          path = `${path}/index`;
         }
 
         return {

--- a/tests/common/util.ts
+++ b/tests/common/util.ts
@@ -6,10 +6,10 @@ import { esbuildPluginFilePathExtensions, type PluginOptions } from '../../dist/
 
 export function createEsbuildConfig(buildOptions: BuildOptions, pluginOptions?: PluginOptions): BuildOptions {
   return {
+    platform: 'node',
     ...buildOptions,
     outdir: buildAbsolutePath('../fixtures/build-out'),
     bundle: true,
-    platform: 'node',
     plugins: [esbuildPluginFilePathExtensions(pluginOptions)]
   };
 }

--- a/tests/fixtures/build-in/directory-import.mjs
+++ b/tests/fixtures/build-in/directory-import.mjs
@@ -1,0 +1,2 @@
+// @ts-ignore: TS can't find the file without `moduleResolution: node*`
+export { foo } from './directory';

--- a/tests/fixtures/build-in/directory/index.mjs
+++ b/tests/fixtures/build-in/directory/index.mjs
@@ -1,0 +1,1 @@
+export const foo = 'bar';

--- a/tests/fixtures/build-in/directory/javascript.mjs
+++ b/tests/fixtures/build-in/directory/javascript.mjs
@@ -1,0 +1,7 @@
+import { exportedTSFunction } from '../../importables/importable';
+import { exportedCJSFunction } from '../../importables/importable.cjs';
+import { exportedMJSFunction } from '../../importables/importable.mjs';
+
+exportedTSFunction();
+exportedCJSFunction();
+exportedMJSFunction();

--- a/tests/fixtures/build-in/node.mts
+++ b/tests/fixtures/build-in/node.mts
@@ -1,0 +1,7 @@
+import assert from 'assert';
+import fs from 'node:fs';
+import fsp from 'node:fs/promises';
+
+assert(true);
+fs.readdirSync('.');
+void fsp.readdir('.');

--- a/tests/scenarios/__snapshots__/directory-import.test.ts.snap
+++ b/tests/scenarios/__snapshots__/directory-import.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`Importing directories > GIVEN a directory import THEN appends "index" to path 1`] = `
 "// tests/fixtures/build-in/directory-import.mjs
-import { foo } from "./directory/index.cjs";
+import { foo } from "./directory/index.mjs";
 export {
   foo
 };

--- a/tests/scenarios/__snapshots__/directory-import.test.ts.snap
+++ b/tests/scenarios/__snapshots__/directory-import.test.ts.snap
@@ -1,0 +1,10 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`Importing directories > GIVEN a directory import THEN appends "index" to path 1`] = `
+"// tests/fixtures/build-in/directory-import.mjs
+import { foo } from "./directory/index.cjs";
+export {
+  foo
+};
+"
+`;

--- a/tests/scenarios/__snapshots__/incorrect-config.test.ts.snap
+++ b/tests/scenarios/__snapshots__/incorrect-config.test.ts.snap
@@ -41,7 +41,7 @@ var require_importable = __commonJS({
 
 // tests/fixtures/build-in/typescript.mts
 var import_importable2 = __toESM(require_importable(), 1);
-import { exportedTSFunction } from "../importables/importable.cjs";
+import { exportedTSFunction } from "../importables/importable.mjs";
 
 // tests/fixtures/importables/importable.mjs
 function exportedMJSFunction() {

--- a/tests/scenarios/__snapshots__/js-based-esm.test.ts.snap
+++ b/tests/scenarios/__snapshots__/js-based-esm.test.ts.snap
@@ -41,7 +41,7 @@ var require_importable = __commonJS({
 
 // tests/fixtures/build-in/javascript.mjs
 var import_importable2 = __toESM(require_importable(), 1);
-import { exportedTSFunction } from "../importables/importable.cjs";
+import { exportedTSFunction } from "../importables/importable.js";
 
 // tests/fixtures/importables/importable.mjs
 function exportedMJSFunction() {
@@ -96,7 +96,7 @@ var require_importable = __commonJS({
 
 // tests/fixtures/build-in/javascript.mjs
 var import_importable2 = __toESM(require_importable(), 1);
-import { exportedTSFunction } from "../importables/importable.cjs";
+import { exportedTSFunction } from "../importables/importable.mjs";
 
 // tests/fixtures/importables/importable.mjs
 function exportedMJSFunction() {

--- a/tests/scenarios/__snapshots__/node-builtins.test.ts.snap
+++ b/tests/scenarios/__snapshots__/node-builtins.test.ts.snap
@@ -2,9 +2,9 @@
 
 exports[`Node builtins > GIVEN platform = "browser" THEN adds extensions to builtins 1`] = `
 "// tests/fixtures/build-in/node.mts
-import assert from "assert.cjs";
-import fs from "node:fs.cjs";
-import fsp from "node:fs/promises.cjs";
+import assert from "assert.mjs";
+import fs from "node:fs.mjs";
+import fsp from "node:fs/promises.mjs";
 assert(true);
 fs.readdirSync(".");
 void fsp.readdir(".");

--- a/tests/scenarios/__snapshots__/node-builtins.test.ts.snap
+++ b/tests/scenarios/__snapshots__/node-builtins.test.ts.snap
@@ -1,0 +1,23 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`Node builtins > GIVEN platform = "browser" THEN adds extensions to builtins 1`] = `
+"// tests/fixtures/build-in/node.mts
+import assert from "assert.cjs";
+import fs from "node:fs.cjs";
+import fsp from "node:fs/promises.cjs";
+assert(true);
+fs.readdirSync(".");
+void fsp.readdir(".");
+"
+`;
+
+exports[`Node builtins > GIVEN platform = "node" THEN does not add extensions to builtins 1`] = `
+"// tests/fixtures/build-in/node.mts
+import assert from "assert";
+import fs from "node:fs";
+import fsp from "node:fs/promises";
+assert(true);
+fs.readdirSync(".");
+void fsp.readdir(".");
+"
+`;

--- a/tests/scenarios/__snapshots__/ts-based-esm.test.ts.snap
+++ b/tests/scenarios/__snapshots__/ts-based-esm.test.ts.snap
@@ -41,7 +41,7 @@ var require_importable = __commonJS({
 
 // tests/fixtures/build-in/typescript.mts
 var import_importable2 = __toESM(require_importable(), 1);
-import { exportedTSFunction } from "../importables/importable.cjs";
+import { exportedTSFunction } from "../importables/importable.js";
 
 // tests/fixtures/importables/importable.mjs
 function exportedMJSFunction() {
@@ -96,7 +96,7 @@ var require_importable = __commonJS({
 
 // tests/fixtures/build-in/typescript.mts
 var import_importable2 = __toESM(require_importable(), 1);
-import { exportedTSFunction } from "../importables/importable.cjs";
+import { exportedTSFunction } from "../importables/importable.mjs";
 
 // tests/fixtures/importables/importable.mjs
 function exportedMJSFunction() {

--- a/tests/scenarios/directory-import.test.ts
+++ b/tests/scenarios/directory-import.test.ts
@@ -1,0 +1,23 @@
+import esbuild, { type BuildOptions } from 'esbuild';
+import { assertFileContent, buildAbsolutePath, createEsbuildConfig } from '../common/util';
+
+function createConfig(): BuildOptions {
+  return createEsbuildConfig({
+    platform: 'node',
+    format: 'esm',
+    outExtension: {
+      '.js': '.mjs'
+    },
+    entryPoints: [buildAbsolutePath('../fixtures/build-in/directory-import.mjs')]
+  });
+}
+
+describe('Importing directories', () => {
+  test('GIVEN a directory import THEN appends "index" to path', async () => {
+    const config = createConfig();
+
+    await esbuild.build(config);
+
+    await assertFileContent('../fixtures/build-out/directory-import.mjs');
+  });
+});

--- a/tests/scenarios/node-builtins.test.ts
+++ b/tests/scenarios/node-builtins.test.ts
@@ -1,0 +1,31 @@
+import esbuild, { type BuildOptions } from 'esbuild';
+import { assertFileContent, buildAbsolutePath, createEsbuildConfig } from '../common/util';
+
+function createConfig(platform: 'node' | 'browser'): BuildOptions {
+  return createEsbuildConfig({
+    platform,
+    format: 'esm',
+    outExtension: {
+      '.js': '.mjs'
+    },
+    entryPoints: [buildAbsolutePath('../fixtures/build-in/node.mts')]
+  });
+}
+
+describe('Node builtins', () => {
+  test('GIVEN platform = "browser" THEN adds extensions to builtins', async () => {
+    const config = createConfig('browser');
+
+    await esbuild.build(config);
+
+    await assertFileContent('../fixtures/build-out/node.mjs');
+  });
+
+  test('GIVEN platform = "node" THEN does not add extensions to builtins', async () => {
+    const config = createConfig('node');
+
+    await esbuild.build(config);
+
+    await assertFileContent('../fixtures/build-out/node.mjs');
+  });
+});

--- a/tests/scenarios/node-builtins.test.ts
+++ b/tests/scenarios/node-builtins.test.ts
@@ -5,9 +5,6 @@ function createConfig(platform: 'node' | 'browser'): BuildOptions {
   return createEsbuildConfig({
     platform,
     format: 'esm',
-    outExtension: {
-      '.js': '.mjs'
-    },
     entryPoints: [buildAbsolutePath('../fixtures/build-in/node.mts')]
   });
 }

--- a/tests/scenarios/node-builtins.test.ts
+++ b/tests/scenarios/node-builtins.test.ts
@@ -5,6 +5,9 @@ function createConfig(platform: 'node' | 'browser'): BuildOptions {
   return createEsbuildConfig({
     platform,
     format: 'esm',
+    outExtension: {
+      '.js': '.mjs'
+    },
     entryPoints: [buildAbsolutePath('../fixtures/build-in/node.mts')]
   });
 }


### PR DESCRIPTION
This PR adds support for handling:

- Directory imports (`import x from "./directory"` where the file is `./directory/index.js`) 
- Node builtins (`import path from "path"`)

I first added tests to verify that these cases would be handled incorrectly, after which I fixed them 😄

Not sure if this is a `feat` or a `fix`

At least partially fixes #6