### PR TITLE
fix: check path starts with deps instead of equality for subpath import support

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -98,9 +98,8 @@ async function isDefinedDependency(path: string): Promise<boolean> {
     return Object.keys(allDependencies).some((dep) => {
       const depParts = dep.split('/');
       const pathParts = path.split('/');
-      const maxLength = depParts.length + 1;
 
-      return pathParts.slice(0, maxLength).join('/') === dep;
+      return pathParts.slice(0, depParts.length).join('/') === dep;
     });
   } catch (error) {
     return false;

--- a/src/index.ts
+++ b/src/index.ts
@@ -87,13 +87,21 @@ async function isDefinedDependency(path: string): Promise<boolean> {
   try {
     const packageJsonPath = join(process.cwd(), 'package.json');
     const packageJson = JSON.parse(await readFile(packageJsonPath, { encoding: 'utf-8' }));
-    const { dependencies, devDependencies, peerDependencies } = packageJson;
+    const { dependencies = {}, devDependencies = {}, peerDependencies = {} } = packageJson;
 
-    const dependenciesExist = Object.keys(dependencies ?? {}).some((dep) => path.startsWith(dep));
-    const devDependenciesExist = Object.keys(devDependencies ?? {}).some((dep) => path.startsWith(dep));
-    const peerDependenciesExist = Object.keys(peerDependencies ?? {}).some((dep) => path.startsWith(dep));
+    const allDependencies = {
+      ...dependencies,
+      ...devDependencies,
+      ...peerDependencies
+    };
 
-    return dependenciesExist || devDependenciesExist || peerDependenciesExist;
+    return Object.keys(allDependencies).some((dep) => {
+      const depParts = dep.split('/');
+      const pathParts = path.split('/');
+      const maxLength = depParts.length + 1;
+
+      return pathParts.slice(0, maxLength).join('/') === dep;
+    });
   } catch (error) {
     return false;
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -89,9 +89,9 @@ async function isDefinedDependency(path: string): Promise<boolean> {
     const packageJson = JSON.parse(await readFile(packageJsonPath, { encoding: 'utf-8' }));
     const { dependencies, devDependencies, peerDependencies } = packageJson;
 
-    const dependenciesExist = Object.keys(dependencies ?? {}).some((dep) => dep === path);
-    const devDependenciesExist = Object.keys(devDependencies ?? {}).some((dep) => dep === path);
-    const peerDependenciesExist = Object.keys(peerDependencies ?? {}).some((dep) => dep === path);
+    const dependenciesExist = Object.keys(dependencies ?? {}).some((dep) => path.startsWith(dep));
+    const devDependenciesExist = Object.keys(devDependencies ?? {}).some((dep) => path.startsWith(dep));
+    const peerDependenciesExist = Object.keys(peerDependencies ?? {}).some((dep) => path.startsWith(dep));
 
     return dependenciesExist || devDependenciesExist || peerDependenciesExist;
   } catch (error) {


### PR DESCRIPTION
This PR adds support for handling subpath imports.

Before fix:
https://github.com/KaisSalha/esbuild-plugin-file-path-extensions-bug

After fix:
https://github.com/KaisSalha/esbuild-plugin-file-path-extensions-bug/tree/with-fix