### PR TITLE
docs: default value for cjsExtension is "cjs"

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -32,7 +32,7 @@ export interface PluginOptions {
    * The extension to apply for CJS code.
    * @remark Make sure to **NOT** start with a leading `.`.
    *
-   * @default 'js'
+   * @default 'cjs'
    */
   cjsExtension?: string | ((initialOptions: BuildOptions) => Awaitable<string>);
   /**


### PR DESCRIPTION
as per: https://github.com/favware/esbuild-plugin-file-path-extensions/blob/3d5a3205f984d7db3de15f83d21f2ce24035b55a/src/index.ts#L153